### PR TITLE
FFmpeg and libraries linking update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The FFmpeg build script provides an easy way to build a static FFmpeg on **OSX**
 
 ## Disclaimer
 Use this script at your own risk. I maintain this script in my spare time. 
-Please do not file bug reports for systems other than Debian 9 and macOS 10.13
+Please do not file bug reports for systems other than Debian 10 and macOS 10.15.x
 because I don't have the resources and the time to maintain other systems.
 
 
@@ -42,7 +42,7 @@ Requirements OSX
 
 Requirements Linux
 ------------
-* Debian >= Wheezy, Ubuntu => Trusty, other Distros might work too
+* Debian >= Buster, Ubuntu => Trusty, other Distros might work too
 * build-essentials installed:
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ because I don't have the resources and the time to maintain other systems.
 * `vorbis`: Lossy audio compression format
 * `theora`: Free lossy video compression format
 * `opus`: Lossy audio coding format
-* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected
+* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected, follow [these](#Cuda-installation) instructions for installation
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with https://travis-ci.org just to make sure everything works as expected.
@@ -82,6 +82,11 @@ git clone https://github.com/markus-perl/ffmpeg-build-script.git
 cd ffmpeg-build-script
 ./build-ffmpeg --help
 ```
+
+
+### Cuda installation
+
+To be able to install CUDA, you first need a compatible NVIDIA GPU.  Once you have the GPU and display driver installed, you can follow the [official instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) or [this blog](https://www.pugetsystems.com/labs/hpc/How-To-Install-CUDA-10-1-on-Ubuntu-19-04-1405/) to setup CUDA
 
 Usage
 ------

--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ because I don't have the resources and the time to maintain other systems.
 
 
 ## Supported Codecs
-* x264: H.264 (MPEG-4 AVC)
-* x265: H.265 Video Codec
-* aom: AV1 Video Codec (Experimental and very slow!)
-* fdk_aac: Fraunhofer FDK AAC Codec 
-* xvidcore: MPEG-4 video coding standard
-* webm: WebM is a video file format
-* mp3: MPEG-1 or MPEG-2 Audio Layer III
-* ogg: Free, open container format
-* vorbis: Lossy audio compression format
-* theora: Free lossy video compression format
-* opus: Lossy audio coding format
+* `x264`: H.264 (MPEG-4 AVC)
+* `x265`: H.265 Video Codec
+* `aom`: AV1 Video Codec (Experimental and very slow!)
+* `fdk_aac`: Fraunhofer FDK AAC Codec 
+* `xvidcore`: MPEG-4 video coding standard
+* `webm`: WebM is a video file format
+* `mp3`: MPEG-1 or MPEG-2 Audio Layer III
+* `ogg`: Free, open container format
+* `vorbis`: Lossy audio compression format
+* `theora`: Free lossy video compression format
+* `opus`: Lossy audio coding format
+* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with https://travis-ci.org just to make sure everything works as expected.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,20 @@ because I don't have the resources and the time to maintain other systems.
 * `vorbis`: Lossy audio compression format
 * `theora`: Free lossy video compression format
 * `opus`: Lossy audio coding format
-* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected, follow [these](#Cuda-installation) instructions for installation
+* `nv-codec`: [NVIDIA's GPU accelerated video codecs](https://devblogs.nvidia.com/nvidia-ffmpeg-transcoding-guide/). Installation is triggered only if CUDA installation is detected, follow [these](#Cuda-installation) instructions for installation. Supported codecs
+    * Decoders
+        * H264 `h264_cuvid`
+        * H265 `hevc_cuvid`
+        * Motion JPEG `mjpeg_cuvid`
+        * MPEG1 video `mpeg1_cuvid`
+        * MPEG2 video `mpeg2_cuvid`
+        * MPEG4 part 2 video `mepg4_cuvid`
+        * VC-1 `vc1_cuvid`
+        * VP8 `vp8_cuvid`
+        * VP9 `vp9_cuvid`
+    * Encoders
+        * H264 `nvenc nvenc_h264`
+        * H265 `nvenc_hevc` 
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with https://travis-ci.org just to make sure everything works as expected.
@@ -108,6 +121,7 @@ Tested on
 
 * Mac OSX 10.14 64Bit XCode 11.0
 * Debian 9.11
+* CemtOS  7.7 (Without Lib AOM and Lib Openssl activated)
 
 Example
 -------

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -379,14 +379,17 @@ if which nvcc > /dev/null ; then
        LDFLAGS="$LDFLAGS -L/usr/local/cuda/lib64"
        ADDITIONAL_CONFIGURE_OPTIONS="$ADDITIONAL_CONFIGURE_OPTIONS --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-libnpp"
 fi
+echo $WORKSPACE
 
 build "ffmpeg"
-download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/47773f7979d77c1fcd08b57e85af1ad08d9248c8.tar.gz" "ffmpeg-snapshot.tar.bz2"
-cd $PACKAGES/ffmpeg-47773f7/ || exit
+download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/192d1d34eb3668fa27f433e96036340e1e5077a0.tar.gz" "ffmpeg-snapshot.tar.bz2"
+cd $PACKAGES/ffmpeg-192d1d3/ || exit
 ./configure $ADDITIONAL_CONFIGURE_OPTIONS \
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \
     --pkg-config-flags="--static" \
+    --extra-cflags="-I$WORKSPACE/include" \
+    --extra-ldflags="-L$WORKSPACE/lib" \
     --extra-cflags="$CFLAGS" \
     --extra-ldflags="$LDFLAGS" \
     --extra-libs="-lpthread -lm" \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -2,7 +2,7 @@
 
 # https://github.com/markus-perl/ffmpeg-build-script
 
-VERSION=1.7
+VERSION=1.8
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"
@@ -242,8 +242,8 @@ if build "xvidcore"; then
 fi
 
 if build "x264"; then
-	download "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20191008-2245-stable.tar.bz2" "last_x264.tar.bz2"
-	cd $PACKAGES/x264-snapshot-* || exit
+	download "https://code.videolan.org/videolan/x264/-/archive/stable/x264-stable.tar.bz2" "last_x264.tar.bz2"
+	cd $PACKAGES/x264-stable || exit
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		execute ./configure --prefix=${WORKSPACE} --enable-static --enable-pic CXXFLAGS="-fPIC"
@@ -318,7 +318,7 @@ if build "vid_stab"; then
 fi
 
 if build "x265"; then
-	download "https://bitbucket.org/multicoreware/x265/downloads/x265_3.2.tar.gz" "x265-3.2.tar.gz"
+	download "https://bitbucket.org/multicoreware/x265/downloads/x265_3.2.1.tar.gz" "x265-3.2.1.tar.gz"
 	cd $PACKAGES/x265_* || exit
 	cd source || exit
 	execute cmake -DCMAKE_INSTALL_PREFIX:PATH=${WORKSPACE} -DENABLE_SHARED:bool=off .
@@ -368,8 +368,8 @@ if build "openssl"; then
 fi
 
 build "ffmpeg"
-download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/6023b9fbfef02b71f6acfb1b09e5a12fe9d276e2.tar.gz" "ffmpeg-snapshot.tar.bz2"
-cd $PACKAGES/ffmpeg-6023b9f/ || exit
+download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/47773f7979d77c1fcd08b57e85af1ad08d9248c8.tar.gz" "ffmpeg-snapshot.tar.bz2"
+cd $PACKAGES/ffmpeg-47773f7/ || exit
 ./configure $ADDITIONAL_CONFIGURE_OPTIONS \
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -367,6 +367,19 @@ if build "openssl"; then
 	build_done "openssl"
 fi
 
+if which nvcc > /dev/null ; then
+       if build "nv-codec"; then
+               download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n9.1.23.0/nv-codec-headers-9.1.23.0.tar.gz" "nv-codec-headers-9.1.23.0.tar.gz"
+               cd $PACKAGES/nv-codec-headers-n9.1.23.0 || exit
+               sed -i  "s#PREFIX = /usr/local#PREFIX = ${WORKSPACE}#g" $PACKAGES/nv-codec-headers-n9.1.23.0/Makefile
+               execute make install
+               build_done "nv-codec"
+       fi
+       CFLAGS="$CFLAGS -I/usr/local/cuda/include"
+       LDFLAGS="$LDFLAGS -L/usr/local/cuda/lib64"
+       ADDITIONAL_CONFIGURE_OPTIONS="$ADDITIONAL_CONFIGURE_OPTIONS --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-libnpp"
+fi
+
 build "ffmpeg"
 download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/47773f7979d77c1fcd08b57e85af1ad08d9248c8.tar.gz" "ffmpeg-snapshot.tar.bz2"
 cd $PACKAGES/ffmpeg-47773f7/ || exit
@@ -374,8 +387,8 @@ cd $PACKAGES/ffmpeg-47773f7/ || exit
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \
     --pkg-config-flags="--static" \
-    --extra-cflags="-I$WORKSPACE/include" \
-    --extra-ldflags="-L$WORKSPACE/lib" \
+    --extra-cflags="$CFLAGS" \
+    --extra-ldflags="$LDFLAGS" \
     --extra-libs="-lpthread -lm" \
 	--enable-static \
 	--disable-debug \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -406,7 +406,7 @@ cd $PACKAGES/ffmpeg-6023b9f/ || exit
 execute make -j $MJOBS
 execute make install
 
-    INSTALL_FOLDER="/usr/bin"
+INSTALL_FOLDER="/usr/bin"
 if [[ "$OSTYPE" == "darwin"* ]]; then
 INSTALL_FOLDER="/usr/local/bin"
 fi
@@ -421,20 +421,25 @@ if [[ $AUTOINSTALL == "yes" ]]; then
 		sudo cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
 		sudo cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
 		echo "Done. ffmpeg is now installed to your system"
+	else
+		cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
+		cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
+		echo "Done. ffmpeg is now installed to your system"
 	fi
 elif [[ ! $SKIPINSTALL == "yes" ]]; then
-	if command_exists "sudo"; then
-
-		read -r -p "Install the binary to your $INSTALL_FOLDER folder? [Y/n] " response
-
-		case $response in
-    		[yY][eE][sS]|[yY])
-        		sudo cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
-        		sudo cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
-        		echo "Done. ffmpeg is now installed to your system"
-        		;;
-		esac
-	fi
+	read -r -p "Install the binary to your $INSTALL_FOLDER folder? [Y/n] " response
+	case $response in
+	[yY][eE][sS]|[yY])
+		if command_exists "sudo"; then
+			sudo cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
+			sudo cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
+		else
+			cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
+			cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
+		fi
+		echo "Done. ffmpeg is now installed to your system"
+		;;
+	esac
 fi
 
 exit 0

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -388,10 +388,8 @@ cd $PACKAGES/ffmpeg-192d1d3/ || exit
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \
     --pkg-config-flags="--static" \
-    --extra-cflags="-I$WORKSPACE/include" \
-    --extra-ldflags="-L$WORKSPACE/lib" \
-    --extra-cflags="$CFLAGS" \
-    --extra-ldflags="$LDFLAGS" \
+    --extra-cflags="-I$WORKSPACE/include $CFLAGS" \
+    --extra-ldflags="-L$WORKSPACE/lib $LDFLAGS" \
     --extra-libs="-lpthread -lm" \
 	--enable-static \
 	--disable-debug \


### PR DESCRIPTION
This PR updates FFmpeg to version 4.2.2 and solves issues with the Libraries linking.

Tested on CentOS 7 (With Openssl and Lib AOM options disabled)